### PR TITLE
Handle optional dependencies and add env template

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,17 @@
+# Default configuration for the Pi5 Swedish Voice Assistant
+# Replace placeholder values with your actual settings before deployment.
+
+OPENAI_API_KEY=your-openai-api-key
+CHAT_MODEL=gpt-4o-mini
+TTS_MODEL=gpt-4o-mini-tts
+TTS_VOICE=alloy
+STT_MODEL=whisper-1
+SAMPLE_RATE=16000
+MAX_RECORD_SECONDS=12
+SILENCE_DURATION=1.0
+ENERGY_THRESHOLD=0.015
+INPUT_DEVICE=
+PLAY_CMD=aplay -q
+OUTPUT_WAV_PATH=/tmp/reply.wav
+HOST=0.0.0.0
+PORT=8080

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,5 @@
+"""Backend package exposing configuration utilities and services."""
+
+from . import config  # re-export for convenience
+
+__all__ = ["config"]

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,7 +1,19 @@
-
 import os
-from dotenv import load_dotenv
-load_dotenv()
+from importlib import import_module, util
+
+
+def _load_dotenv() -> None:
+    """Load environment variables from a ``.env`` file if python-dotenv exists."""
+
+    spec = util.find_spec("dotenv")
+    if spec is None:
+        return
+    module = import_module("dotenv")
+    if hasattr(module, "load_dotenv"):
+        module.load_dotenv()
+
+
+_load_dotenv()
 
 def env(key: str, default: str | None = None):
     return os.getenv(key, default)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,4 @@ extend-ignore = ["E203", "W503"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+pythonpath = ["."]

--- a/scripts/list_audio.py
+++ b/scripts/list_audio.py
@@ -1,10 +1,63 @@
 #!/usr/bin/env python3
-import sounddevice as sd
-print("=== INPUT DEVICES (Mics) ===")
-for i, dev in enumerate(sd.query_devices()):
-    if dev['max_input_channels'] > 0:
-        print(f"[{i}] {dev['name']}  ({dev['hostapi']})")
-print("\n=== OUTPUT DEVICES (Speakers) ===")
-for i, dev in enumerate(sd.query_devices()):
-    if dev['max_output_channels'] > 0:
-        print(f"[{i}] {dev['name']}  ({dev['hostapi']})")
+"""Utility script for listing the available audio devices.
+
+The original script unconditionally imported :mod:`sounddevice`, which caused
+the program to exit with a ``ModuleNotFoundError`` when the optional
+dependency was not installed.  The test-suite (and general usability) expects
+the script to fail gracefully in that situation, so we dynamically check for
+the module and provide a helpful message instead.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module, util
+
+
+def _load_sounddevice():
+    """Return the ``sounddevice`` module if it is available.
+
+    ``sounddevice`` is an optional dependency.  By checking availability via
+    :func:`importlib.util.find_spec` we avoid importing it when the package is
+    missing, which keeps the script runnable on systems without audio
+    hardware or the dependency installed.
+    """
+
+    spec = util.find_spec("sounddevice")
+    if spec is None:
+        return None
+    return import_module("sounddevice")
+
+
+def _print_devices(
+    devices,
+    *,
+    channel_key: str,
+    header: str,
+    empty_message: str = "(no devices detected)",
+) -> None:
+    print(header)
+    printed_any = False
+    for index, device in enumerate(devices):
+        if device.get(channel_key, 0) > 0:
+            print(f"[{index}] {device['name']}  ({device['hostapi']})")
+            printed_any = True
+    if not printed_any:
+        print(empty_message)
+
+
+def main() -> int:
+    sounddevice = _load_sounddevice()
+    if sounddevice is None:
+        print("sounddevice is not installed; unable to list audio devices.")
+        devices = []
+    else:
+        devices = sounddevice.query_devices()
+
+    _print_devices(devices, channel_key="max_input_channels", header="=== INPUT DEVICES (Mics) ===")
+    print()
+    _print_devices(devices, channel_key="max_output_channels", header="=== OUTPUT DEVICES (Speakers) ===")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - script entry point
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- allow importing the backend package without python-dotenv by lazily loading environment support
- make the audio device listing script resilient to a missing sounddevice installation while still showing section headers
- add a default .env template and ensure pytest always includes the project root on sys.path

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbb7c14c3483208b8637e12779d0d9