### PR TITLE
Fix openwakeword dependency for Python 3.11

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ python-dotenv==1.0.1
 sounddevice==0.4.7
 numpy==1.26.4
 webrtcvad==2.0.10
-openwakeword==0.7.0
+openwakeword==0.6.0
 pydantic==2.8.2
 httpx==0.27.0
 starlette==0.37.2


### PR DESCRIPTION
## Summary
- Downgrade the openwakeword requirement to 0.6.0 so it can be installed with Python 3.11+

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbc4468fc08320a08b6fc60df26ef8