### PR TITLE
Add openwakeword models package

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ sudo systemctl start pi5-assistant
 - **Chat**: `gpt-4o-mini` (snabbt/billigt) med svensk systemprompt.
 - **TTS**: OpenAI TTS (`gpt-4o-mini-tts`) → WAV → uppspelning med `aplay`.
 - **Wakeword**: `openwakeword` (lokalt, låg CPU).
+- **Wakeword-modeller**: `openwakeword-models` installeras via `requirements.txt` så att de förtränade TFLite-filerna finns lokalt.
 - **Frontend**: Statisk HTML/JS med stor touchknapp, status och text.
 
 ## Konfig

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ sounddevice==0.4.7
 numpy==1.26.4
 webrtcvad==2.0.10
 openwakeword==0.6.0
+openwakeword-models==0.6.0
 pydantic==2.8.2
 httpx==0.27.0
 starlette==0.37.2


### PR DESCRIPTION
## Summary
- add the openwakeword-models package pinned to 0.6.0 alongside openwakeword so the bundled models install with the app
- document in the README that requirements.txt pulls in the pre-trained wake word models

## Testing
- ⚠️ `pip install -r requirements.txt` *(fails in CI because outbound network access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc0acdc7a08320acd8d75f48d0978d