### PR TITLE
Fix openwakeword models dependency issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ sudo systemctl start pi5-assistant
 - **Chat**: `gpt-4o-mini` (snabbt/billigt) med svensk systemprompt.
 - **TTS**: OpenAI TTS (`gpt-4o-mini-tts`) → WAV → uppspelning med `aplay`.
 - **Wakeword**: `openwakeword` (lokalt, låg CPU).
-- **Wakeword-modeller**: `openwakeword-models` installeras via `requirements.txt` så att de förtränade TFLite-filerna finns lokalt.
+- **Wakeword-modeller**: `openwakeword` laddar automatiskt hem standardmodellerna vid första körningen (cache i `~/.cache/openwakeword`).
 - **Frontend**: Statisk HTML/JS med stor touchknapp, status och text.
 
 ## Konfig

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ sounddevice==0.4.7
 numpy==1.26.4
 webrtcvad==2.0.10
 openwakeword==0.6.0
-openwakeword-models==0.6.0
 pydantic==2.8.2
 httpx==0.27.0
 starlette==0.37.2


### PR DESCRIPTION
## Summary
- remove the unused `openwakeword-models` dependency that no longer has published wheels
- clarify in the README that `openwakeword` downloads its default models on demand

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc0c03d6108320bc99a547d965ba14