### PR TITLE
Handle missing openwakeword models gracefully

### DIFF
--- a/tests/test_wakeword_recovery.py
+++ b/tests/test_wakeword_recovery.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+from backend import wakeword
+
+
+def test_extract_missing_model_path_from_error_message():
+    error = ValueError("Could not open '/tmp/fake/models/alexa_v0.1.tflite'")
+
+    result = wakeword._extract_missing_model_path(error)
+
+    assert result == Path("/tmp/fake/models/alexa_v0.1.tflite")
+
+
+def test_extract_missing_model_path_when_not_present():
+    error = RuntimeError("some other failure")
+
+    result = wakeword._extract_missing_model_path(error)
+
+    assert result is None


### PR DESCRIPTION
## Summary
- add a recovery path in the wake word listener that detects missing openwakeword model files, downloads the official defaults, and retries initialisation
- make wake word support optional when the openwakeword package is not installed and improve the logging around recovery attempts
- cover the helper that parses missing-model paths with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc0ce6a34c8320b39ce768ab17dbb6