### PR TITLE
Improve wake word model recovery fallback

### DIFF
--- a/tests/test_wakeword_recovery.py
+++ b/tests/test_wakeword_recovery.py
@@ -1,4 +1,7 @@
+import io
 from pathlib import Path
+from typing import List
+from urllib.error import HTTPError
 
 from backend import wakeword
 
@@ -17,3 +20,41 @@ def test_extract_missing_model_path_when_not_present():
     result = wakeword._extract_missing_model_path(error)
 
     assert result is None
+
+
+class _DummyResponse(io.BytesIO):
+    def __enter__(self):  # pragma: no cover - simple helper
+        return self
+
+    def __exit__(self, exc_type, exc, tb):  # pragma: no cover - simple helper
+        self.close()
+
+
+def test_try_recover_missing_model_uses_fallback_url(monkeypatch, tmp_path):
+    model_name = "alexa_v0.1.tflite"
+    target_path = tmp_path / "models" / model_name
+    attempted_urls: List[str] = []
+
+    monkeypatch.setattr(
+        wakeword,
+        "MODEL_BASE_URLS",
+        ("https://primary.example/", "https://fallback.example/"),
+    )
+
+    def fake_urlopen(request, timeout=0):
+        url = request.full_url if hasattr(request, "full_url") else request
+        attempted_urls.append(url)
+        if len(attempted_urls) == 1:
+            raise HTTPError(url, 404, "Not Found", hdrs=None, fp=None)
+        return _DummyResponse(b"wakeword")
+
+    monkeypatch.setattr(wakeword.urllib.request, "urlopen", fake_urlopen)
+
+    recovered = wakeword._try_recover_missing_model(target_path)
+
+    assert recovered is True
+    assert target_path.exists()
+    assert attempted_urls == [
+        "https://primary.example/" + model_name,
+        "https://fallback.example/" + model_name,
+    ]


### PR DESCRIPTION
## Summary
- add multiple fallback locations for downloading missing wake word models and improve error handling
- ensure wake word recovery includes a User-Agent header before requesting files
- add a regression test covering the multi-URL fallback logic

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc0e848c6c83208b1507f87523fdbe