### PR TITLE
Add fallback wake word detector and tests

### DIFF
--- a/backend/wakeword.py
+++ b/backend/wakeword.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 
 import logging
 import re
@@ -9,6 +10,8 @@ import urllib.request
 from urllib.error import HTTPError
 from pathlib import Path
 from typing import Callable, List, Optional, Tuple
+
+import math
 
 try:
     from openwakeword import Model
@@ -24,44 +27,63 @@ logger = logging.getLogger(__name__)
 
 
 class WakeWordListener:
-    def __init__(self, on_detect: Callable[[], None], detection_threshold: float = 0.5):
+    def __init__(
+        self,
+        on_detect: Callable[[], None],
+        detection_threshold: float = 0.5,
+        *,
+        fallback_energy_threshold: float = 0.2,
+        fallback_required_blocks: int = 15,
+    ):
         self.on_detect = on_detect
         self.detection_threshold = detection_threshold
         self._stop = threading.Event()
         self.model: Optional[Model] = None
         self._thread: Optional[threading.Thread] = None
+        self._detector: Optional[_BaseWakeWordDetector] = None
+        self._detector_name = "none"
+
+        def configure_fallback_detector(reason: str) -> None:
+            logger.warning(
+                "%s; falling back to simple energy-based trigger.",
+                reason,
+            )
+            self._detector = _EnergyWakeWordDetector(
+                energy_threshold=fallback_energy_threshold,
+                required_consecutive_blocks=fallback_required_blocks,
+            )
+            self._detector_name = "energy"
 
         # Laddar standardmodeller (engelska/svenska kan fungera okej för enkla fraser).
         if Model is None:
-            logger.warning(
-                "openwakeword is not installed; wake word detection disabled. Install the optional dependency to enable it."
-            )
+            configure_fallback_detector("openwakeword is not installed")
             return
         try:
             self.model = Model(enable_speex_noise_suppression=True)
         except Exception as exc:  # pragma: no cover - defensive guard against optional dependency issues
-            recovered = False
             missing_path = _extract_missing_model_path(exc)
-            if missing_path:
-                recovered = _try_recover_missing_model(missing_path)
-                if recovered:
-                    try:
-                        self.model = Model(enable_speex_noise_suppression=True)
-                    except Exception as second_exc:  # pragma: no cover - still failing → log original context
-                        logger.warning(
-                            "Wake word model could not be loaded even after attempting recovery: %s",
-                            second_exc,
-                        )
-                        return
-            if not recovered:
-                logger.warning(
-                    "Wake word model could not be loaded, disabling wake word detection: %s",
-                    exc,
+            if missing_path and _try_recover_missing_model(missing_path):
+                try:
+                    self.model = Model(enable_speex_noise_suppression=True)
+                except Exception as second_exc:  # pragma: no cover - still failing → log original context
+                    logger.warning(
+                        "Wake word model could not be loaded even after attempting recovery: %s",
+                        second_exc,
+                    )
+                    self.model = None
+            if self.model is None:
+                configure_fallback_detector(
+                    f"Wake word model could not be loaded: {exc}"
                 )
+                return
+
+        assert self.model is not None  # För typkontroll
+        self._detector = _OpenWakeWordDetector(self.model, detection_threshold)
+        self._detector_name = "openwakeword"
 
     def start(self):
-        if self.model is None:
-            logger.info("Wake word listener not started because no model is available.")
+        if self._detector is None:
+            logger.info("Wake word listener not started because no detector is available.")
             return False
 
         if self._thread and self._thread.is_alive():
@@ -78,28 +100,119 @@ class WakeWordListener:
             self._thread.join(timeout=0.1)
 
     def _run(self):
-        if self.model is None:
+        if self._detector is None:
             return
         import sounddevice as sd
-        import numpy as np
+        try:
+            import numpy as np
+        except ImportError:  # pragma: no cover - numpy bör finnas i produktion
+            np = None  # type: ignore[assignment]
         samplerate = 16000
         blocksize = 512
         with sd.InputStream(channels=1, samplerate=samplerate, blocksize=blocksize, dtype="float32") as stream:
             while not self._stop.is_set():
                 audio_block, _ = stream.read(blocksize)
-                y = audio_block[:,0].astype(float)
-                # Skicka till openwakeword (BERÄKNING)
-                scores = self.model.predict(y)
-                # 'scores' är dict över kända nyckelord i modellen. Vi approximerar här:
-                # Om någon score går över tröskeln och vi hittar textlikhet mot vår fraslista → trigga.
-                # (För robusthet kan man byta till en tränad modell för "hej kompis".)
-                max_score = 0.0
-                for _, s in scores.items():
-                    max_score = max(max_score, float(s))
-                if max_score >= self.detection_threshold:
-                    # Debounce
+                if np is not None:
+                    y = audio_block[:, 0].astype(np.float32)
+                else:  # pragma: no cover - numpy saknas endast i testmiljöer
+                    y = [float(sample[0]) for sample in audio_block]
+                if self._detector.process(y):
                     self.on_detect()
-                    time.sleep(2.0)  # undvik retrigger direkt
+                    time.sleep(getattr(self._detector, "cooldown", 2.0))
+
+    @property
+    def detector_name(self) -> str:
+        return self._detector_name
+
+
+class _BaseWakeWordDetector:
+    cooldown: float = 2.0
+
+    def process(self, audio) -> bool:  # pragma: no cover - interface definition only
+        raise NotImplementedError
+
+
+class _OpenWakeWordDetector(_BaseWakeWordDetector):
+    def __init__(self, model: Model, detection_threshold: float) -> None:
+        self.model = model
+        self.detection_threshold = detection_threshold
+        self.cooldown = 2.0
+
+    def process(self, audio) -> bool:
+        scores = self.model.predict(audio)
+        max_score = 0.0
+        for _, score in scores.items():
+            max_score = max(max_score, float(score))
+        return max_score >= self.detection_threshold
+
+
+class _EnergyWakeWordDetector(_BaseWakeWordDetector):
+    """Naiv reservlösning: trigga om rösten är tillräckligt stark en stund."""
+
+    def __init__(
+        self,
+        *,
+        energy_threshold: float = 0.2,
+        required_consecutive_blocks: int = 15,
+        cooldown: float = 2.0,
+        time_source: Optional[Callable[[], float]] = None,
+    ) -> None:
+        if required_consecutive_blocks <= 0:
+            raise ValueError("required_consecutive_blocks must be positive")
+        self.energy_threshold = energy_threshold
+        self.required_consecutive_blocks = required_consecutive_blocks
+        self.cooldown = cooldown
+        self._time = time_source or time.monotonic
+        self._consecutive = 0
+        self._last_trigger = float("-inf")
+
+    def process(self, audio) -> bool:
+        now = self._time()
+        if (now - self._last_trigger) < self.cooldown:
+            return False
+
+        if _audio_length(audio) == 0:
+            self._consecutive = 0
+            return False
+
+        energy = _rms_energy(audio)
+        if energy >= self.energy_threshold:
+            self._consecutive += 1
+        else:
+            self._consecutive = 0
+
+        if self._consecutive >= self.required_consecutive_blocks:
+            self._consecutive = 0
+            self._last_trigger = now
+            return True
+        return False
+
+
+def _audio_length(audio) -> int:
+    try:
+        return len(audio)
+    except TypeError:  # pragma: no cover - defensive fallback
+        return 0
+
+
+def _rms_energy(audio) -> float:
+    try:
+        import numpy as np
+    except ImportError:  # pragma: no cover - testmiljö utan numpy
+        total = 0.0
+        count = 0
+        for sample in audio:
+            value = float(sample)
+            total += value * value
+            count += 1
+        if count == 0:
+            return 0.0
+        return math.sqrt(total / count)
+
+    arr = np.asarray(audio, dtype=np.float32)
+    if arr.size == 0:
+        return 0.0
+    return float(np.sqrt(np.mean(np.square(arr))))
 
 
 def _extract_missing_model_path(exc: Exception) -> Optional[Path]:

--- a/tests/test_wakeword_fallback_detector.py
+++ b/tests/test_wakeword_fallback_detector.py
@@ -1,0 +1,72 @@
+from backend import wakeword
+
+def test_energy_detector_triggers_after_sustained_energy():
+    clock = [0.0]
+
+    def advance(delta: float) -> None:
+        clock[0] += delta
+
+    def fake_time() -> float:
+        return clock[0]
+
+    detector = wakeword._EnergyWakeWordDetector(
+        energy_threshold=0.2,
+        required_consecutive_blocks=3,
+        cooldown=1.0,
+        time_source=fake_time,
+    )
+
+    low = [0.0] * 512
+    high = [0.5] * 512
+
+    assert detector.process(low) is False
+
+    advance(0.05)
+    assert detector.process(high) is False
+
+    advance(0.05)
+    assert detector.process(high) is False
+
+    advance(0.05)
+    assert detector.process(high) is True
+
+    # Cooldown aktiv → ingen ny trigger direkt
+    assert detector.process(high) is False
+
+    advance(1.1)
+
+    # Låg energi nollställer räknaren
+    assert detector.process(low) is False
+
+    advance(0.05)
+    assert detector.process(high) is False
+
+    advance(0.05)
+    assert detector.process(high) is False
+
+    advance(0.05)
+    assert detector.process(high) is True
+
+
+def test_listener_uses_energy_fallback_when_model_missing(monkeypatch):
+    monkeypatch.setattr(wakeword, "Model", None)
+
+    listener = wakeword.WakeWordListener(on_detect=lambda: None)
+
+    assert listener.detector_name == "energy"
+
+
+def test_listener_uses_openwakeword_when_available(monkeypatch):
+    class DummyModel:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def predict(self, audio):
+            return {"hej": 0.7}
+
+    monkeypatch.setattr(wakeword, "Model", DummyModel)
+
+    listener = wakeword.WakeWordListener(on_detect=lambda: None, detection_threshold=0.5)
+
+    assert listener.detector_name == "openwakeword"
+


### PR DESCRIPTION
## Summary
- refactor WakeWordListener to support detector plugins and log which detector is active
- add a simple energy-based wake word fallback when openwakeword is unavailable and handle numpy-less environments
- cover the new fallback detector behaviour with unit tests

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68cc13a911808320bab0bccf55797d91