### PR TITLE
Switch wake word detection to Porcupine

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ python-dotenv==1.0.1
 sounddevice==0.4.7
 numpy==1.26.4
 webrtcvad==2.0.10
-openwakeword==0.6.0
+pvporcupine==3.0.3
 pydantic==2.8.2
 httpx==0.27.0
 starlette==0.37.2

--- a/tests/test_wakeword_recovery.py
+++ b/tests/test_wakeword_recovery.py
@@ -1,60 +1,53 @@
-import io
-from pathlib import Path
-from typing import List
-from urllib.error import HTTPError
-
 from backend import wakeword
 
 
-def test_extract_missing_model_path_from_error_message():
-    error = ValueError("Could not open '/tmp/fake/models/alexa_v0.1.tflite'")
+def test_parse_env_list_splits_and_expands_home(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    value = " first.ppn , , ~/second.ppn "
 
-    result = wakeword._extract_missing_model_path(error)
+    result = wakeword._parse_env_list(value)
 
-    assert result == Path("/tmp/fake/models/alexa_v0.1.tflite")
-
-
-def test_extract_missing_model_path_when_not_present():
-    error = RuntimeError("some other failure")
-
-    result = wakeword._extract_missing_model_path(error)
-
-    assert result is None
+    assert result == ["first.ppn", str(tmp_path / "second.ppn")]
 
 
-class _DummyResponse(io.BytesIO):
-    def __enter__(self):  # pragma: no cover - simple helper
-        return self
-
-    def __exit__(self, exc_type, exc, tb):  # pragma: no cover - simple helper
-        self.close()
-
-
-def test_try_recover_missing_model_uses_fallback_url(monkeypatch, tmp_path):
-    model_name = "alexa_v0.1.tflite"
-    target_path = tmp_path / "models" / model_name
-    attempted_urls: List[str] = []
-
-    monkeypatch.setattr(
-        wakeword,
-        "MODEL_BASE_URLS",
-        ("https://primary.example/", "https://fallback.example/"),
+def test_porcupine_kwargs_default_keyword():
+    kwargs = wakeword._porcupine_create_kwargs(
+        0.3,
+        keywords_env=None,
+        keyword_paths_env=None,
+        access_key=None,
     )
 
-    def fake_urlopen(request, timeout=0):
-        url = request.full_url if hasattr(request, "full_url") else request
-        attempted_urls.append(url)
-        if len(attempted_urls) == 1:
-            raise HTTPError(url, 404, "Not Found", hdrs=None, fp=None)
-        return _DummyResponse(b"wakeword")
+    assert kwargs["keywords"] == ["porcupine"]
+    assert kwargs["sensitivities"] == [0.3]
+    assert "access_key" not in kwargs
 
-    monkeypatch.setattr(wakeword.urllib.request, "urlopen", fake_urlopen)
 
-    recovered = wakeword._try_recover_missing_model(target_path)
+def test_porcupine_kwargs_prefers_keyword_paths(tmp_path):
+    first = tmp_path / "hej.ppn"
+    second = tmp_path / "kompis.ppn"
+    kwargs = wakeword._porcupine_create_kwargs(
+        1.4,
+        keywords_env="ignored",
+        keyword_paths_env=f"{first},{second}",
+        access_key="abc",
+    )
 
-    assert recovered is True
-    assert target_path.exists()
-    assert attempted_urls == [
-        "https://primary.example/" + model_name,
-        "https://fallback.example/" + model_name,
+    assert kwargs["keyword_paths"] == [str(first), str(second)]
+    assert kwargs["sensitivities"] == [1.0, 1.0]
+    assert kwargs["access_key"] == "abc"
+    assert "keywords" not in kwargs
+
+
+def test_ensure_int16_clamps_samples():
+    pcm = wakeword._ensure_int16([-2.0, -1.0, -0.5, 0.0, 0.5, 1.0, 2.0])
+
+    assert list(map(int, pcm)) == [
+        -32767,
+        -32767,
+        -16383,
+        0,
+        16383,
+        32767,
+        32767,
     ]


### PR DESCRIPTION
## Summary
- replace the openWakeWord integration with a Porcupine-based detector that falls back to the existing energy trigger when unavailable
- add configuration helpers for parsing Porcupine keyword paths, converting audio frames, and clamping sensitivities
- update dependency requirements and tests to exercise the new Porcupine behaviour and configuration helpers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc170201808320864150c1fff24a98