### PR TITLE
Require Picovoice access key for Porcupine wake word

### DIFF
--- a/backend/wakeword.py
+++ b/backend/wakeword.py
@@ -274,6 +274,12 @@ def _porcupine_create_kwargs(
     keywords = _parse_env_list(keywords_env)
 
     kwargs: dict[str, Any] = {}
+
+    if not access_key:
+        raise ValueError(
+            "PICOVOICE_ACCESS_KEY must be set to use Porcupine wake word detection"
+        )
+
     if keyword_paths:
         kwargs["keyword_paths"] = keyword_paths
         count = len(keyword_paths)
@@ -287,7 +293,6 @@ def _porcupine_create_kwargs(
     sensitivity = _clamp_sensitivity(detection_threshold)
     kwargs["sensitivities"] = [sensitivity] * count
 
-    if access_key:
-        kwargs["access_key"] = access_key
+    kwargs["access_key"] = access_key
 
     return kwargs

--- a/tests/test_wakeword_fallback_detector.py
+++ b/tests/test_wakeword_fallback_detector.py
@@ -1,3 +1,5 @@
+import pytest
+
 from backend import wakeword
 
 def test_energy_detector_triggers_after_sustained_energy():
@@ -82,11 +84,22 @@ def test_listener_uses_porcupine_when_available(monkeypatch):
     monkeypatch.setattr(wakeword, "pvporcupine", dummy_module)
     monkeypatch.delenv("PORCUPINE_KEYWORDS", raising=False)
     monkeypatch.delenv("PORCUPINE_KEYWORD_PATHS", raising=False)
-    monkeypatch.delenv("PICOVOICE_ACCESS_KEY", raising=False)
+    monkeypatch.setenv("PICOVOICE_ACCESS_KEY", "dummy-access-key")
 
     listener = wakeword.WakeWordListener(on_detect=lambda: None, detection_threshold=0.7)
 
     assert listener.detector_name == "porcupine"
     assert dummy_module.kwargs["keywords"] == ["porcupine"]
     assert dummy_module.kwargs["sensitivities"] == [0.7]
+    assert dummy_module.kwargs["access_key"] == "dummy-access-key"
+
+
+def test_porcupine_requires_access_key():
+    with pytest.raises(ValueError):
+        wakeword._porcupine_create_kwargs(
+            0.5,
+            keywords_env=None,
+            keyword_paths_env=None,
+            access_key=None,
+        )
 

--- a/tests/test_wakeword_recovery.py
+++ b/tests/test_wakeword_recovery.py
@@ -15,12 +15,12 @@ def test_porcupine_kwargs_default_keyword():
         0.3,
         keywords_env=None,
         keyword_paths_env=None,
-        access_key=None,
+        access_key="abc",
     )
 
     assert kwargs["keywords"] == ["porcupine"]
     assert kwargs["sensitivities"] == [0.3]
-    assert "access_key" not in kwargs
+    assert kwargs["access_key"] == "abc"
 
 
 def test_porcupine_kwargs_prefers_keyword_paths(tmp_path):


### PR DESCRIPTION
## Summary
- require the PICOVOICE_ACCESS_KEY environment variable before initialising the Porcupine wake word detector
- update wake word unit tests to provide an access key and cover the missing-key error path

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc1a3da3f08320b00327c44daba91b