### PR TITLE
Handle empty transcriptions before RAG lookup

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -78,7 +78,12 @@ async def full_converse_flow(trigger: str = "touch", *, suspend_wakeword: bool =
         wav_bytes = buf.getvalue()
 
         text = await stt_transcribe_wav(wav_bytes, language="sv")
+        text = (text or "").strip()
         await notify(f"du: {text}")
+
+        if not text:
+            await notify("status: Hörde inget – försök igen.")
+            return {"ok": False, "error": "empty_transcription"}
 
         await notify("status: Söker i kunskapsbas ...")
         rag = await rag_answer(text)


### PR DESCRIPTION
## Summary
- trim the transcription result before use
- short circuit the conversation flow when no text was detected to avoid RAG errors

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd12859a888320a8c7d0ac3bd306c8