### PR TITLE
Update kiosk desktop shortcut path

### DIFF
--- a/desktop/pi5-assistant-kiosk.desktop
+++ b/desktop/pi5-assistant-kiosk.desktop
@@ -2,7 +2,7 @@
 Type=Application
 Name=GENIO Assistant (Kiosk)
 Comment=Starta GENIO AI i helskärmsläge (Chromium kiosk).
-Exec=/home/pi/apps/GENIO/scripts/pi5-assistant-kiosk.sh
+Exec=/home/apps/genio/scripts/pi5-assistant-kiosk.sh
 Icon=chromium-browser
 Terminal=false
 Categories=Utility;AudioVideo;


### PR DESCRIPTION
## Summary
- point the kiosk desktop shortcut to the new installation directory under /home/apps/genio

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cfb2e8e4f48320b66d76ff2ca4806a