### PR TITLE
Add missing assistant title heading to frontend

### DIFF
--- a/backend/static/index.html
+++ b/backend/static/index.html
@@ -150,6 +150,7 @@
 <body>
   <div class="brand" id="assistant-brand">Pi5 Röstassistent</div>
   <div class="wrap">
+    <h1 id="assistant-title">Pi5 Röstassistent</h1>
     <div class="actions">
       <button class="btn" id="talk">Tryck för att prata</button>
     </div>


### PR DESCRIPTION
## Summary
- render a visible assistant title heading in the kiosk UI so UI updates succeed

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d00343aafc832097e8a9a3dc013a69