### PR TITLE
Respect audio output device selection with playback command

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -395,6 +395,11 @@ async def full_converse_flow(trigger: str = "touch") -> dict:
     wav_reply = await tts_speak_sv(reply)
     wav_reply = ensure_wav_pcm16(wav_reply)
 
+    # Om en specifik ljudutgång valts ska sounddevice ta hand om uppspelningen
+    # eftersom externa kommandon (t.ex. aplay/paplay) alltid använder
+    # systemets standard. Då ignoreras användarens valda enhet.
+    prefer_sounddevice = get_selected_output_device() is not None
+
     # Spara och spela upp
     out_path = OUTPUT_WAV_PATH
     with open(out_path, "wb") as f:
@@ -402,7 +407,7 @@ async def full_converse_flow(trigger: str = "touch") -> dict:
 
     played = False
     play_cmd = (PLAY_CMD or "").strip()
-    if play_cmd:
+    if play_cmd and not prefer_sounddevice:
         try:
             subprocess.run(shlex.split(play_cmd) + [out_path], check=True)
             played = True

--- a/tests/test_app_playback.py
+++ b/tests/test_app_playback.py
@@ -1,0 +1,116 @@
+import sys
+import types
+
+import numpy as np
+import pytest
+
+
+class DummyRag:
+    used_rag = False
+    answer = "svar"
+
+    def context_payload(self):
+        return "[]"
+
+    def contexts_for_client(self):
+        return []
+
+
+def _prepare_common_flow(monkeypatch, tmp_path, *, selected_device):
+    if "multipart" not in sys.modules:
+        multipart = types.ModuleType("multipart")
+        multipart.__version__ = "0"
+        sys.modules["multipart"] = multipart
+        multipart_submodule = types.ModuleType("multipart.multipart")
+
+        def _parse_options_header(value):  # pragma: no cover - tiny stub
+            return value, {}
+
+        multipart_submodule.parse_options_header = _parse_options_header
+        sys.modules["multipart.multipart"] = multipart_submodule
+
+    from backend import app
+
+    notifications = []
+
+    async def fake_notify(message):
+        notifications.append(message)
+
+    monkeypatch.setattr(app, "notify", fake_notify)
+    monkeypatch.setattr(
+        app,
+        "record_until_silence",
+        lambda: np.array([0.1, -0.2, 0.3], dtype=np.float32),
+    )
+    monkeypatch.setattr(app, "save_wav_mono16", lambda buf, audio: buf.write(b"pcm"))
+
+    async def fake_stt(wav_bytes, *, language="sv"):
+        return "hej"
+
+    monkeypatch.setattr(app, "stt_transcribe_wav", fake_stt)
+
+    async def fake_rag(text):
+        return DummyRag()
+
+    monkeypatch.setattr(app, "rag_answer", fake_rag)
+
+    async def fake_tts(text):
+        return b"raw-wav"
+
+    monkeypatch.setattr(app, "tts_speak_sv", fake_tts)
+    monkeypatch.setattr(app, "ensure_wav_pcm16", lambda data: b"final-wav")
+    monkeypatch.setattr(app, "OUTPUT_WAV_PATH", tmp_path / "reply.wav")
+    monkeypatch.setattr(app, "PLAY_CMD", "aplay -q")
+    monkeypatch.setattr(app, "get_selected_output_device", lambda: selected_device)
+
+    play_calls = []
+
+    def fake_play_wav_bytes(data):
+        play_calls.append(data)
+
+    monkeypatch.setattr(app, "play_wav_bytes", fake_play_wav_bytes)
+
+    run_calls = []
+
+    def fake_run(*args, **kwargs):
+        run_calls.append((args, kwargs))
+
+    monkeypatch.setattr(app.subprocess, "run", fake_run)
+
+    return app, notifications, play_calls, run_calls
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_full_converse_flow_skips_play_cmd_when_device_selected(monkeypatch, tmp_path):
+    app, notifications, play_calls, run_calls = _prepare_common_flow(
+        monkeypatch, tmp_path, selected_device=7
+    )
+
+    result = await app.full_converse_flow(trigger="test")
+
+    assert result["ok"] is True
+    assert run_calls == []
+    assert play_calls == [b"final-wav"]
+    assert any("Lyssnar" in msg for msg in notifications)
+
+
+@pytest.mark.anyio("asyncio")
+async def test_full_converse_flow_uses_play_cmd_without_selected_device(
+    monkeypatch, tmp_path
+):
+    app, notifications, play_calls, run_calls = _prepare_common_flow(
+        monkeypatch, tmp_path, selected_device=None
+    )
+
+    result = await app.full_converse_flow(trigger="test")
+
+    assert result["ok"] is True
+    assert run_calls, "play command should be invoked when no device is selected"
+    # ensure sounddevice fallback not used when command succeeds
+    assert play_calls == []
+    assert any("Lyssnar" in msg for msg in notifications)


### PR DESCRIPTION
## Summary
- skip invoking the configured playback command when a specific output device has been selected so sounddevice can honor the choice
- add regression tests that stub the conversation flow to ensure the playback command is only used when no device is selected

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d54a55bf608320af6ed726f94e1681