### PR TITLE
Fix Voice API transcription payload

### DIFF
--- a/backend/ai.py
+++ b/backend/ai.py
@@ -250,15 +250,10 @@ class OpenAIProvider(BaseAIProvider):
         voice_request = {
             "model": self._stt_model,
             "modalities": ["text"],
-            "input": [
+            "input_audio": [
                 {
-                    "role": "user",
-                    "content": [
-                        {
-                            "type": "input_audio",
-                            "audio": {"data": audio_payload, "format": "wav"},
-                        }
-                    ],
+                    "data": audio_payload,
+                    "format": "wav",
                 }
             ],
         }


### PR DESCRIPTION
## Summary
- update the OpenAI Voice API transcription request to use the input_audio payload expected by the Responses endpoint
- keep the language instruction while relying on the legacy transcription as a fallback when no text is returned

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d629caf71c83209f0cb340e794e29c