### PR TITLE
Fix OpenAI voice synthesis payload format

### DIFF
--- a/backend/ai.py
+++ b/backend/ai.py
@@ -316,19 +316,8 @@ class OpenAIProvider(BaseAIProvider):
         self._require_api_key()
         payload = {
             "model": self._tts_model,
-            "modalities": ["audio"],
+            "input": text,
             "audio": {"voice": self._tts_voice, "format": "wav"},
-            "input": [
-                {
-                    "role": "user",
-                    "content": [
-                        {
-                            "type": "input_text",
-                            "text": text,
-                        }
-                    ],
-                }
-            ],
         }
 
         try:

--- a/tests/test_ai_openai.py
+++ b/tests/test_ai_openai.py
@@ -79,9 +79,9 @@ async def test_openai_synthesize_decodes_json_wav(monkeypatch):
     assert recorder.post_calls, "HTTP POST should have been invoked"
     request_json = recorder.post_calls[0]["json"]
     assert recorder.post_calls[0]["url"].endswith("/responses")
-    assert request_json["modalities"] == ["audio"]
+    assert request_json["model"] == "model"
     assert request_json["audio"] == {"voice": "alloy", "format": "wav"}
-    assert request_json["input"][0]["content"][0]["text"] == "hej"
+    assert request_json["input"] == "hej"
 
 
 @pytest.mark.anyio("asyncio")


### PR DESCRIPTION
## Summary
- update the OpenAI TTS request payload to use the Responses API input format
- adjust the OpenAI provider unit test to match the new payload structure

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d62bf9e33883209edae6da1dcda1bd