### PR TITLE
Fix OpenAI responses payloads for voice features

### DIFF
--- a/backend/ai.py
+++ b/backend/ai.py
@@ -290,11 +290,20 @@ class OpenAIProvider(BaseAIProvider):
         audio_payload = base64.b64encode(wav_bytes).decode("ascii") if wav_bytes else ""
         voice_request = {
             "model": self._stt_model,
-            "modalities": ["text"],
-            "input_audio": [
+            "input": [
                 {
-                    "data": audio_payload,
-                    "format": "wav",
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "input_audio",
+                            "audio": [
+                                {
+                                    "data": audio_payload,
+                                    "format": "wav",
+                                }
+                            ],
+                        }
+                    ],
                 }
             ],
         }
@@ -387,7 +396,6 @@ class OpenAIProvider(BaseAIProvider):
 
         payload = {
             "model": self._chat_model,
-            "modalities": ["text"],
             "input": inputs,
         }
 
@@ -422,8 +430,14 @@ class OpenAIProvider(BaseAIProvider):
 
         payload = {
             "model": self._tts_model,
-            "modalities": ["audio"],
-            "input": cleaned_text,
+            "input": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": cleaned_text},
+                    ],
+                }
+            ],
             "audio": {"voice": self._tts_voice, "format": "wav"},
         }
 

--- a/tests/test_ai_openai.py
+++ b/tests/test_ai_openai.py
@@ -81,7 +81,14 @@ async def test_openai_synthesize_decodes_json_wav(monkeypatch):
     assert recorder.post_calls[0]["url"].endswith("/responses")
     assert request_json["model"] == "model"
     assert request_json["audio"] == {"voice": "alloy", "format": "wav"}
-    assert request_json["input"] == "hej"
+    assert request_json["input"] == [
+        {
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": "hej"},
+            ],
+        }
+    ]
 
 
 @pytest.mark.anyio("asyncio")
@@ -239,7 +246,7 @@ async def test_openai_chat_reply_uses_responses_api(monkeypatch):
     request_json = recorder.post_calls[0]["json"]
     assert recorder.post_calls[0]["url"].endswith("/responses")
     assert request_json["model"] == "model"
-    assert request_json["modalities"] == ["text"]
+    assert request_json["input"][0]["role"] == "system"
     assert request_json["input"][-1]["role"] == "user"
     assert request_json["input"][-1]["content"][0]["type"] == "input_text"
     # Context should be present in a system message
@@ -274,7 +281,8 @@ async def test_openai_chat_reply_falls_back_to_legacy(monkeypatch):
 
     assert reply == "Fallback-svar"
     assert "payload" in call_args
-    assert call_args["payload"]["modalities"] == ["text"]
+    assert call_args["payload"]["input"][0]["role"] == "system"
+    assert call_args["payload"]["input"][-1]["role"] == "user"
     assert recorder.post_calls, "Fallback chat completions should have been invoked"
     assert recorder.post_calls[0]["url"].endswith("/chat/completions")
 


### PR DESCRIPTION
## Summary
- update the OpenAI voice provider to send Responses API payloads that include `input` content for transcription, chat, and TTS
- refresh the OpenAI provider unit tests to assert the new payload layout

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d686a3ded883209b6d527f75e57508